### PR TITLE
Support for custom PDF CSS

### DIFF
--- a/assets/admin/css/pdf-generator.css
+++ b/assets/admin/css/pdf-generator.css
@@ -1,14 +1,35 @@
 .ppn-container {
-		margin-top: 10px;
+	margin-top: 10px;
 }
+
 .ppn-item {
-		margin-top: 10px;
+	display: inline-block;
+	width: 100%;
+	margin-top: 5px;
+	margin-bottom: 10px;
+	vertical-align: top;
+}
+
+.ppn-item label {
+	width: 30%;
+	float: left;
+	text-align: right;
+	margin-right: 1em;
+}
+
+.ppn-item-list {
+	display: inline-block;
+	float: left;
+}
+
+.ppn-item-list ul {
+	margin-top: 0;
 }
 
 #ppn-post-type, #ppn-tag-id, #ppn-category-id {
-		width: 375px;
+	width: 375px;
 }
 
 .ppn-item-hidden {
-		display: none;
+	display: none;
 }

--- a/assets/admin/css/pdf-template-styles.css
+++ b/assets/admin/css/pdf-template-styles.css
@@ -1,3 +1,9 @@
+/**
+ * This CSS file is output as inline styles used by TCPDF in generating the final PDF file.
+ * These styles can be appended to in the admin Printable PDF configuration form, or
+ * by using the ppn_pdf_template_css_file_path() filter.
+ */
+
 .ppn-article-title {
 	font-family: 'Lora-Bold', serif;
 	font-size: 16pt;

--- a/assets/admin/css/pdf-template-styles.css
+++ b/assets/admin/css/pdf-template-styles.css
@@ -1,0 +1,45 @@
+.ppn-article-title {
+	font-family: 'Lora-Bold', serif;
+	font-size: 16pt;
+	text-align: left;
+}
+
+.ppn-article-wrapper p {
+	font-size: 10pt;
+	font-family: 'Roboto', sans-serif;
+}
+
+.ppn-author {
+	color: rgb(102, 102, 102);
+	font-family: 'Roboto', sans-serif;
+}
+
+.ppn-author strong {
+	font-family: 'Roboto-Bold', sans-serif;
+}
+
+.ppn-date {
+	color: #666;
+	line-height: 100%;
+}
+
+.ppn-content, .ppn-excerpt {
+	color: rgb(102, 102, 102);
+	font-size: 10pt;
+	font-family: 'Roboto', sans-serif;
+	text-indent: 20px;
+}
+
+.ppn-permalink-text {
+	font-weight: bold;
+	white-space: nowrap;
+	text-indent: 20px;
+}
+
+.ppn-permalink-qr-code-image {
+	text-align: center;
+}
+
+.ppn-article-bottom-border {
+	border-top: 1px dashed #d7d7d7;
+}

--- a/assets/admin/css/pdf-template-styles.css
+++ b/assets/admin/css/pdf-template-styles.css
@@ -1,9 +1,8 @@
-/**
- * This CSS file is output as inline styles used by TCPDF in generating the final PDF file.
- * These styles can be appended to in the admin Printable PDF configuration form, or
- * by using the ppn_pdf_template_css_file_path() filter.
- */
-
+/*
+This CSS file is output as inline styles used by TCPDF in generating the final PDF file.
+These styles can be appended to in the admin Printable PDF configuration form, or
+by using the ppn_pdf_template_css_file_path() filter. See the plugin FAQ for more.
+*/
 .ppn-article-title {
 	font-family: 'Lora-Bold', serif;
 	font-size: 16pt;

--- a/classes/class-admin-ajax.php
+++ b/classes/class-admin-ajax.php
@@ -54,12 +54,12 @@ class Ajax {
 			$filename    = $pdf->get_link();
 			$wp_filetype = wp_check_filetype( basename( $filename ) );
 
-			$attachment = [
+			$attachment = array(
 				'post_mime_type' => $wp_filetype['type'],
 				'post_title'     => sanitize_file_name( basename( $filename ) ),
 				'post_content'   => '',
 				'post_status'    => 'inherit',
-			];
+			);
 
 			$attach_id   = wp_insert_attachment( $attachment, $filename );
 			$attach_data = wp_generate_attachment_metadata( $attach_id, $filename );

--- a/classes/class-admin-pdf-handler.php
+++ b/classes/class-admin-pdf-handler.php
@@ -47,10 +47,10 @@ class PdfHandler {
 			$url = get_attached_file( $image_id );
 			if ( in_array(
 				mime_content_type( $url ),
-				[
+				array(
 					'image/jpeg',
 					'image/png',
-				],
+				),
 				true
 			)
 			) {
@@ -124,7 +124,7 @@ class PdfHandler {
 
 		// Set up some footer properties
 		$pdf->setFooterMargin( 25 );
-		$pdf->setFooterFont( [ 'roboto', 'regular', 10 ] );
+		$pdf->setFooterFont( array( 'roboto', 'regular', 10 ) );
 
 		// Margins defined in units defined above
 		// 15 for top margin on pages 2+

--- a/classes/class-admin-pdf-handler.php
+++ b/classes/class-admin-pdf-handler.php
@@ -181,9 +181,15 @@ class PdfHandler {
 
 		$css_to_include = $this->configure['custom_css'];
 
+		// Allow customization of the default CSS file to use.
+		$default_css_file = apply_filters(
+			'ppn_pdf_template_css_file_path',
+			plugin_dir_path( __DIR__ ) . 'assets/admin/css/pdf-template-styles.css'
+		);
+
 		ob_start();
 		echo '<style>';
-		include plugin_dir_path( __DIR__ ) . 'assets/admin/css/pdf-template-styles.css';
+		include $default_css_file;
 
 		if ( $css_to_include ) {
 			echo esc_html( $css_to_include );

--- a/classes/class-admin-pdf-handler.php
+++ b/classes/class-admin-pdf-handler.php
@@ -109,10 +109,16 @@ class PdfHandler {
 		}
 
 		// Include some fonts to be used
-		TCPDF_FONTS::addTTFfont( plugin_dir_path( __DIR__ ) . 'assets/fonts/ttf/robotoregular.ttf' );
-		TCPDF_FONTS::addTTFfont( plugin_dir_path( __DIR__ ) . 'assets/fonts/ttf/RobotoBold.ttf' );
-		TCPDF_FONTS::addTTFfont( plugin_dir_path( __DIR__ ) . 'assets/fonts/ttf/RobotoRegularItalic.ttf' );
-		TCPDF_FONTS::addTTFfont( plugin_dir_path( __DIR__ ) . 'assets/fonts/ttf/lorabold.ttf' );
+		$fonts_to_include = array(
+			plugin_dir_path( __DIR__ ) . 'assets/fonts/ttf/robotoregular.ttf',
+			plugin_dir_path( __DIR__ ) . 'assets/fonts/ttf/RobotoBold.ttf',
+			plugin_dir_path( __DIR__ ) . 'assets/fonts/ttf/RobotoRegularItalic.ttf',
+			plugin_dir_path( __DIR__ ) . 'assets/fonts/ttf/lorabold.ttf',
+		);
+
+		foreach ( apply_filters( 'ppn_font_file_paths', $fonts_to_include ) as $font_path ) {
+			TCPDF_FONTS::addTTFfont( $font_path );
+		}
 
 		// Adjust font settings for each.
 		// $family, $style, $size

--- a/classes/class-admin-pdf-handler.php
+++ b/classes/class-admin-pdf-handler.php
@@ -179,7 +179,18 @@ class PdfHandler {
 	 */
 	private function render_template( $posts_to_include = null ) {
 
+		$css_to_include = $this->configure['custom_css'];
+
 		ob_start();
+		echo '<style>';
+		include plugin_dir_path( __DIR__ ) . 'assets/admin/css/pdf-template-styles.css';
+
+		if ( $css_to_include ) {
+			echo esc_html( $css_to_include );
+		}
+
+		echo '</style>';
+
 		include plugin_dir_path( __DIR__ ) . 'views/admin/pdf/pdf-template.php';
 		$content = ob_get_contents();
 		ob_end_clean();

--- a/classes/class-admin-post-handler.php
+++ b/classes/class-admin-post-handler.php
@@ -112,8 +112,9 @@ class PostHandler {
 			$text = $this->truncate( $text, $length );
 		}
 
-		$text = str_replace( "\n\n", "\n<br />&nbsp;&nbsp;&nbsp;", $text );
-		$text = '&nbsp;&nbsp;&nbsp;' . $text;
+		// Replace two line breaks with a single line break (for source readability) and an HTML line break.
+		// TODO: one can end up in a situation of having multiple <br /> tags next to each other.
+		$text = (string) str_replace( "\n\n", "\n<br />", $text );
 
 		return $text;
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -52,6 +52,7 @@ Here are the CSS classes you may wish to adjust:
 You can view the default style definitions in the plugin file `assets/admin/css/pdf-template-styles.css` or [in Trac](https://plugins.trac.wordpress.org/browser/printable-pdf-newspaper/trunk/assets/admin/css/pdf-template-styles.css).
 
 Note that TCPDF only supports a limited subset of the full CSS specification. Also note that any fonts referenced must be available in the TCPDF library used to generate the PDF. You can [view the TCPDF core font list](https://tcpdf.org/docs/fonts/).
+There's also an experimental filter, `ppn_font_file_paths`, that allows you to add to or change the array of TTF font file paths being loaded.
 
 Currently the header image size/position and subheading styles are not easily customizable, but will be in the future.
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,6 @@
 === Printable PDF Newspaper ===
 Contributors: chrishardie
+Donate link: https://chrishardie.com/refer/donate
 Tags: print,pdf,newspaper,newsletter,journalism,news
 Stable tag: trunk
 Requires at least: 5.2.2
@@ -30,11 +31,34 @@ Printable PDF Newspaper is most easily installed via the Plugins tab in your adm
 
 == Frequently Asked Questions ==
 
+= How can I customize the PDF content styles? =
+
+You can customize the PDF newspaper layout and styles using limited CSS definitions, in two different ways:
+
+1. Enter your custom style definitions in the "Custom CSS" input field when generating the PDF.
+1. In your theme, filter the output of `ppn_pdf_template_css_file_path` to specify the full filesystem path to a file containing CSS styles.
+
+Here are the CSS classes you may wish to adjust:
+
+* *ppn-article-title*: Headlines / post titles
+* *ppn-article-wrapper*: Wrapper around the loop of all included articles
+* *ppn-author*: Author byline and display name (if included)
+* *ppn-date*: Article date (if included)
+* *ppn-content* and *ppn-excerpt*: article body content
+* *ppn-permalink-text*: the "Continue Reading" permalink introductory text
+* *ppn-permalink-qr-code-image*: image class for the QR Code (if included)
+* *ppn-article-bottom-border*: horizontal line dividing articles
+
+You can view the default style definitions in the plugin file `assets/admin/css/pdf-template-styles.css` or [in Trac](https://plugins.trac.wordpress.org/browser/printable-pdf-newspaper/trunk/assets/admin/css/pdf-template-styles.css).
+
+Note that TCPDF only supports a limited subset of the full CSS specification. Also note that any fonts referenced must be available in the TCPDF library used to generate the PDF. You can [view the TCPDF core font list](https://tcpdf.org/docs/fonts/).
+
+Currently the header image size/position and subheading styles are not easily customizable, but will be in the future.
+
 = What features will be added in the future? =
 
 * Allow saving of PDF configuration for easy re-use in future runs
 * More customizable header size and layout
-* Better support for additional formatting and styles
 * Filters to alter how content is selected and laid out
 * Generate QR Codes within the plugin instead of Google Chart API
 * Ability to auto-generate the PDF on a schedule

--- a/views/admin/config-form.php
+++ b/views/admin/config-form.php
@@ -52,7 +52,7 @@
 				<label for="ppn-content-length">
 					<b><?php esc_attr_e( 'Truncate post content at', 'printable-pdf-newspaper' ); ?>:</b>
 				</label>
-				<input id="ppn-content-length" name="configure[length]" style="width: 55px" value="500" min="1" type="number">
+				<input id="ppn-content-length" name="configure[length]" style="width: 80px;" value="500" min="1" type="number">
 				<?php esc_attr_e( 'characters', 'printable-pdf-newspaper' ); ?>
 				(<?php esc_attr_e( 'blank for full content', 'printable-pdf-newspaper' ); ?>)
 			</div>
@@ -68,7 +68,6 @@
 				</label>
 				<input id="ppn-content-columns" name="configure[columns]" style="width: 55px" value="3" min="1" max="3" type="number">
 			</div>
-
 			<div class="ppn-item ppn-item-after-selection">
 				<label for="ppn-header-image">
 					<b><?php esc_attr_e( 'Select a masthead image', 'printable-pdf-newspaper' ); ?>:</b>
@@ -80,37 +79,37 @@
 				<input type="hidden" id="image_attachment_id" name="configure[image]">
 			</div>
 			<div class="ppn-item ppn-item-after-selection">
-				<b><?php esc_attr_e( 'Which items should be included', 'printable-pdf-newspaper' ); ?>?</b>:
-				<p>
-					<label>
+				<label for="ppn-custom-css">
+					<b><?php esc_attr_e( 'Custom CSS', 'printable-pdf-newspaper' ); ?>:</b>
+				</label>
+				<textarea id="ppn-custom-css" name="configure[custom_css]" rows="10" cols="55"></textarea>
+			</div>
+			<div class="ppn-item ppn-item-after-selection ppn-include-items">
+				<label for="ppn-items"><b><?php esc_attr_e( 'Which items should be included', 'printable-pdf-newspaper' ); ?>?</b></label>
+				<div class="ppn-item-list">
+				<ul>
+					<li>
 						<input checked name="configure[items][title]" type="checkbox">
 						<?php esc_attr_e( 'Title', 'printable-pdf-newspaper' ); ?>
-					</label>
-				</p>
-				<p>
-					<label>
+					</li>
+				<li>
 						<input checked name="configure[items][author]" type="checkbox">
 						<?php esc_attr_e( 'Author', 'printable-pdf-newspaper' ); ?>
-					</label>
-				</p>
-				<p>
-					<label>
+				</li>
+				<li>
 						<input checked name="configure[items][date]" type="checkbox">
 						<?php esc_attr_e( 'Date', 'printable-pdf-newspaper' ); ?>
-					</label>
-				</p>
-				<p>
-					<label>
+				</li>
+				<li>
 						<input checked name="configure[items][image]" type="checkbox">
 						<?php esc_attr_e( 'Featured image', 'printable-pdf-newspaper' ); ?>
-					</label>
-				</p>
-				<p>
-					<label>
+				</li>
+				<li>
 						<input checked name="configure[items][permalink]" type="checkbox">
 						<?php esc_attr_e( 'Permalink QR Code', 'printable-pdf-newspaper' ); ?>
-					</label>
-				</p>
+				</li>
+				</ul>
+				</div>
 			</div>
 
 

--- a/views/admin/pdf/pdf-template.php
+++ b/views/admin/pdf/pdf-template.php
@@ -39,10 +39,11 @@ defined( 'WPINC' ) || die;
 		line-height: 100%;
 	}
 
-	.content, .excerpt {
+	.ppn-content, .ppn-excerpt {
 		color: rgb(102, 102, 102);
 		font-size: 10pt;
 		font-family: 'Roboto', sans-serif;
+		text-indent: 20px;
 	}
 
 	.permalink-text {
@@ -75,7 +76,7 @@ defined( 'WPINC' ) || die;
 				<?php endif; ?>
 			</p>
 		<?php endif; ?>
-		<div class="<?php echo $item['has_excerpt'] ? 'excerpt' : 'content'; ?>">
+		<div class="<?php echo $item['has_excerpt'] ? 'excerpt ppn-excerpt' : 'content ppn-content'; ?>">
 			<?php echo wp_kses_post( $item['content'] ); ?>
 			<?php if ( $item['permalink'] ) : ?>
 				<br /><span class="permalink-text">&nbsp;&nbsp;&nbsp;<?php esc_attr_e( 'Continue&nbsp;Reading', 'printable-pdf-newspaper' ); ?>:</span><br/>

--- a/views/admin/pdf/pdf-template.php
+++ b/views/admin/pdf/pdf-template.php
@@ -71,7 +71,7 @@ defined( 'WPINC' ) || die;
 		<?php if ( ! empty( $item['author'] ) || ! empty( $item['date'] ) ) : ?>
 			<p class="meta ppn-meta">
 				<?php if ( ! empty( $item['author'] ) ) : ?>
-					<span class="author ppn-author"><?php _e( 'By', 'printable-pdf-newspaper' ); ?> <strong><?php echo esc_html( $item['author'] ); ?></strong></span><br />
+					<span class="author ppn-author"><?php esc_attr_e( 'By', 'printable-pdf-newspaper' ); ?> <strong><?php echo esc_html( $item['author'] ); ?></strong></span><br />
 				<?php endif; ?>
 				<?php if ( ! empty( $item['date'] ) ) : ?>
 					<span class="date ppn-date"><?php echo esc_html( $item['date'] ); ?></span>

--- a/views/admin/pdf/pdf-template.php
+++ b/views/admin/pdf/pdf-template.php
@@ -14,7 +14,7 @@ defined( 'WPINC' ) || die;
 ?>
 
 <style>
-	h3{
+	.ppn-article-title {
 		font-family: 'Lora-Bold', serif;
 		font-size: 16pt;
 		text-align: left;
@@ -25,16 +25,16 @@ defined( 'WPINC' ) || die;
 		font-family: 'Roboto', sans-serif;
 	}
 
-	.author{
+	.ppn-author {
 		color: rgb(102, 102, 102);
 		font-family: 'Roboto', sans-serif;
 	}
 
-	.author strong{
+	.ppn-author strong {
 		font-family: 'Roboto-Bold', sans-serif;
 	}
 
-	.date{
+	.ppn-date {
 		color: #666;
 		line-height: 100%;
 	}
@@ -53,30 +53,36 @@ defined( 'WPINC' ) || die;
 		text-align: center;
 	}
 
+	.ppn-article-bottom-border {
+		border-top: 1px dashed #d7d7d7;
+	}
+
 </style>
 
 <?php foreach ( $posts_to_include as $item ) : ?>
-	<?php if ( $item['image'] ) : ?>
-		<p><img src="<?php echo esc_url( $item['image'] ); ?>" alt=""></p>
-	<?php endif; ?>
-	<h3><?php echo esc_html( $item['title'] ); ?></h3>
-	<?php if ( ! empty( $item['author'] ) || ! empty( $item['date'] ) ) : ?>
-		<p class="meta">
-			<?php if ( ! empty( $item['author'] ) ) : ?>
-				<span class="author"><?php _e( 'By', 'printable-pdf-newspaper' ); ?> <strong><?php echo esc_html( $item['author'] ); ?></strong></span><br />
-			<?php endif; ?>
-			<?php if ( ! empty( $item['date'] ) ) : ?>
-				<span class="date"><?php echo esc_html( $item['date'] ); ?></span>
-			<?php endif; ?>
-		</p>
-	<?php endif; ?>
-	<div class="<?php echo $item['has_excerpt'] ? 'excerpt' : 'content'; ?>">
-		<?php echo wp_kses_post( $item['content'] ); ?>
-		<?php if ( $item['permalink'] ) : ?>
-			<br /><span class="permalink-text">&nbsp;&nbsp;&nbsp;<?php esc_attr_e( 'Continue&nbsp;Reading', 'printable-pdf-newspaper' ); ?>:</span><br/>
-			<img src="https://chart.googleapis.com/chart?chs=50x50&chld=M|1&cht=qr&chl=<?php echo esc_url( $item['permalink'] ); ?>"
-				 class="permalink-qr-code-image" width="50" height="50" />
+	<div class="ppn-article-wrapper">
+		<?php if ( $item['image'] ) : ?>
+			<p><img class="ppn-article-image" src="<?php echo esc_url( $item['image'] ); ?>" alt=""></p>
 		<?php endif; ?>
+		<h3 class="ppn-article-title"><?php echo esc_html( $item['title'] ); ?></h3>
+		<?php if ( ! empty( $item['author'] ) || ! empty( $item['date'] ) ) : ?>
+			<p class="meta ppn-meta">
+				<?php if ( ! empty( $item['author'] ) ) : ?>
+					<span class="author ppn-author"><?php _e( 'By', 'printable-pdf-newspaper' ); ?> <strong><?php echo esc_html( $item['author'] ); ?></strong></span><br />
+				<?php endif; ?>
+				<?php if ( ! empty( $item['date'] ) ) : ?>
+					<span class="date ppn-date"><?php echo esc_html( $item['date'] ); ?></span>
+				<?php endif; ?>
+			</p>
+		<?php endif; ?>
+		<div class="<?php echo $item['has_excerpt'] ? 'excerpt' : 'content'; ?>">
+			<?php echo wp_kses_post( $item['content'] ); ?>
+			<?php if ( $item['permalink'] ) : ?>
+				<br /><span class="permalink-text">&nbsp;&nbsp;&nbsp;<?php esc_attr_e( 'Continue&nbsp;Reading', 'printable-pdf-newspaper' ); ?>:</span><br/>
+				<img src="https://chart.googleapis.com/chart?chs=50x50&chld=M|1&cht=qr&chl=<?php echo esc_url( $item['permalink'] ); ?>"
+					 class="permalink-qr-code-image" width="50" height="50" />
+			<?php endif; ?>
+		</div>
+		<p class="ppn-article-bottom-border"></p>
 	</div>
-	<p style="border-top: 1px dashed #d7d7d7;"></p>
 <?php endforeach; ?>

--- a/views/admin/pdf/pdf-template.php
+++ b/views/admin/pdf/pdf-template.php
@@ -46,8 +46,10 @@ defined( 'WPINC' ) || die;
 		text-indent: 20px;
 	}
 
-	.permalink-text {
+	.ppn-permalink-text {
 		font-weight: bold;
+		white-space: nowrap;
+		text-indent: 20px;
 	}
 
 	.permalink-qr-code-image {
@@ -79,7 +81,7 @@ defined( 'WPINC' ) || die;
 		<div class="<?php echo $item['has_excerpt'] ? 'excerpt ppn-excerpt' : 'content ppn-content'; ?>">
 			<?php echo wp_kses_post( $item['content'] ); ?>
 			<?php if ( $item['permalink'] ) : ?>
-				<br /><span class="permalink-text">&nbsp;&nbsp;&nbsp;<?php esc_attr_e( 'Continue&nbsp;Reading', 'printable-pdf-newspaper' ); ?>:</span><br/>
+				<br /><span class="ppn-permalink-text"><?php esc_attr_e( 'Continue Reading', 'printable-pdf-newspaper' ); ?>:</span><br/>
 				<img src="https://chart.googleapis.com/chart?chs=50x50&chld=M|1&cht=qr&chl=<?php echo esc_url( $item['permalink'] ); ?>"
 					 class="permalink-qr-code-image" width="50" height="50" />
 			<?php endif; ?>

--- a/views/admin/pdf/pdf-template.php
+++ b/views/admin/pdf/pdf-template.php
@@ -12,56 +12,6 @@ use PrintablePdfNewspaper\Admin\NewspaperPdf;
 
 defined( 'WPINC' ) || die;
 ?>
-
-<style>
-	.ppn-article-title {
-		font-family: 'Lora-Bold', serif;
-		font-size: 16pt;
-		text-align: left;
-	}
-
-	.ppn-article-wrapper p {
-		font-size: 10pt;
-		font-family: 'Roboto', sans-serif;
-	}
-
-	.ppn-author {
-		color: rgb(102, 102, 102);
-		font-family: 'Roboto', sans-serif;
-	}
-
-	.ppn-author strong {
-		font-family: 'Roboto-Bold', sans-serif;
-	}
-
-	.ppn-date {
-		color: #666;
-		line-height: 100%;
-	}
-
-	.ppn-content, .ppn-excerpt {
-		color: rgb(102, 102, 102);
-		font-size: 10pt;
-		font-family: 'Roboto', sans-serif;
-		text-indent: 20px;
-	}
-
-	.ppn-permalink-text {
-		font-weight: bold;
-		white-space: nowrap;
-		text-indent: 20px;
-	}
-
-	.ppn-permalink-qr-code-image {
-		text-align: center;
-	}
-
-	.ppn-article-bottom-border {
-		border-top: 1px dashed #d7d7d7;
-	}
-
-</style>
-
 <?php foreach ( $posts_to_include as $item ) : ?>
 	<div class="ppn-article-wrapper">
 		<?php if ( $item['image'] ) : ?>

--- a/views/admin/pdf/pdf-template.php
+++ b/views/admin/pdf/pdf-template.php
@@ -20,7 +20,7 @@ defined( 'WPINC' ) || die;
 		text-align: left;
 	}
 
-	p {
+	.ppn-article-wrapper p {
 		font-size: 10pt;
 		font-family: 'Roboto', sans-serif;
 	}
@@ -52,7 +52,7 @@ defined( 'WPINC' ) || die;
 		text-indent: 20px;
 	}
 
-	.permalink-qr-code-image {
+	.ppn-permalink-qr-code-image {
 		text-align: center;
 	}
 
@@ -83,7 +83,7 @@ defined( 'WPINC' ) || die;
 			<?php if ( $item['permalink'] ) : ?>
 				<br /><span class="ppn-permalink-text"><?php esc_attr_e( 'Continue Reading', 'printable-pdf-newspaper' ); ?>:</span><br/>
 				<img src="https://chart.googleapis.com/chart?chs=50x50&chld=M|1&cht=qr&chl=<?php echo esc_url( $item['permalink'] ); ?>"
-					 class="permalink-qr-code-image" width="50" height="50" />
+					 class="ppn-permalink-qr-code-image" width="50" height="50" />
 			<?php endif; ?>
 		</div>
 		<p class="ppn-article-bottom-border"></p>


### PR DESCRIPTION
* Adds custom CSS textarea to PDF generation admin screen
* Moves default styles into dedicated CSS file
* Adds filter `ppn_pdf_template_css_file_path` to change the location of the default CSS file
* Adds filter `ppn_font_file_paths` to alter the array of TTF font file paths
* Cleans up CSS class names
* Adds documentation in the readme for CSS customization
* Other minor cleanup

Fixes #3 



