### PR TITLE
Enable exception throwing and catching for PDF generation

### DIFF
--- a/classes/class-admin-pdf-handler.php
+++ b/classes/class-admin-pdf-handler.php
@@ -159,14 +159,33 @@ class PdfHandler {
 			$align = 'J';
 		}
 
-		$pdf->writeHTML(
-			$this->render_template( $this->posts_to_include ),
-			true,
-			false,
-			true,
-			false,
-			$align
-		);
+		// Try to create the PDF using the template
+		try {
+			$pdf->writeHTML(
+				$this->render_template( $this->posts_to_include ),
+				true,
+				false,
+				true,
+				false,
+				$align
+			);
+		} catch ( \Exception $e ) {
+			$error_message = '';
+			if ( false !== strpos( $e->getMessage(), 'Unable to get the size of the image' ) ) {
+				$error_message = 'Could not process a post featured image; try again without.';
+			}
+			wp_safe_redirect(
+				add_query_arg(
+					array(
+						'ppn_is_error'      => true,
+						'ppn_error_message' => $error_message,
+						'nonce'             => wp_create_nonce( 'ppn_error_nonce' ),
+					),
+					admin_url( 'admin.php?page=printable-pdf-newspaper' )
+				)
+			);
+			exit;
+		}
 
 		// I - show in browser
 		// F - save

--- a/lib/tcpdf/config/tcpdf_config.php
+++ b/lib/tcpdf/config/tcpdf_config.php
@@ -215,7 +215,7 @@ define('K_TCPDF_CALLS_IN_HTML', false);
 /**
  * If true and PHP version is greater than 5, then the Error() method throw new exception instead of terminating the execution.
  */
-define('K_TCPDF_THROW_EXCEPTION_ERROR', false);
+define('K_TCPDF_THROW_EXCEPTION_ERROR', true);
 
 /**
  * Default timezone for datetime functions

--- a/views/admin/config-form.php
+++ b/views/admin/config-form.php
@@ -1,6 +1,23 @@
 <?php defined( 'WPINC' ) || die; ?>
 <div class="wrap">
 	<h1 class="wp-heading-inline"><?php esc_attr_e( 'Printable PDF Newspaper', 'printable-pdf-newspaper' ); ?></h1>
+	<?php
+	if ( ! empty( $_GET['ppn_is_error'] )
+		&& isset( $_GET['nonce'] )
+		&& wp_verify_nonce( $_GET['nonce'], 'ppn_error_nonce' ) ) {
+		?>
+		<div class="notice notice-error">
+			<?php
+			esc_attr_e( 'There was a problem generating the PDF.', 'printable-pdf-newspaper' );
+			if ( ! empty( $_GET['ppn_error_message'] ) ) {
+				echo esc_html( $_GET['ppn_error_message'] );
+			}
+			?>
+		</div>
+		<?php
+	}
+	?>
+
 	<div class="instructions">
 <?php esc_attr_e( 'Configure how you want your printable PDF newspaper to look, and what content it should include.', 'printable-pdf-newspaper' ); ?>
 	</div>


### PR DESCRIPTION
* Throw exceptions instead of echoing errors
* Catch the exceptions
* Return an error to the user that might be helpful
* Provide a little more detail if we know it's a featured image issue

Fixes #32 